### PR TITLE
feat(projects): make projects have multiple orgs

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,8 @@
     "viem": "^2.9.15"
   },
   "devDependencies": {
+    "@faker-js/faker": "^9.0.3",
+    "@fast-check/jest": "^2.0.2",
     "@golevelup/ts-jest": "^0.3.7",
     "@nestjs/cli": "^9.4.2",
     "@nestjs/schematics": "^9.1.0",
@@ -101,6 +103,7 @@
     "eslint": "^8.40.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "fast-check": "^3.22.0",
     "jest": "29.5.0",
     "node-notifier": "^10.0.1",
     "prettier": "^2.8.8",

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -128,7 +128,7 @@ export class JobsService {
               projects: [
                 (organization)-[:HAS_PROJECT]->(project) | project {
                   .*,
-                  orgId: organization.orgId,
+                  orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                   discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                   website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
                   docs: [(project)-[:HAS_DOCSITE]->(docsite) | docsite.url][0],
@@ -816,7 +816,7 @@ export class JobsService {
               projects: [
                 (organization)-[:HAS_PROJECT]->(project) | project {
                   .*,
-                  orgId: organization.orgId,
+                  orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                   discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                   website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
                   docs: [(project)-[:HAS_DOCSITE]->(docsite) | docsite.url][0],
@@ -1066,7 +1066,7 @@ export class JobsService {
               projects: [
                 (organization)-[:HAS_PROJECT]->(project) | project {
                   .*,
-                  orgId: organization.orgId,
+                  orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                   discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                   website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
                   docs: [(project)-[:HAS_DOCSITE]->(docsite) | docsite.url][0],
@@ -1296,7 +1296,7 @@ export class JobsService {
               projects: [
                 (organization)-[:HAS_PROJECT]->(project) | project {
                   .*,
-                  orgId: organization.orgId,
+                  orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                   discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                   website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
                   docs: [(project)-[:HAS_DOCSITE]->(docsite) | docsite.url][0],
@@ -1580,7 +1580,7 @@ export class JobsService {
                 projects: [
                   (organization)-[:HAS_PROJECT]->(project) | project {
                     .*,
-                    orgId: organization.orgId,
+                    orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                     discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                     website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
                     docs: [(project)-[:HAS_DOCSITE]->(docsite) | docsite.url][0],
@@ -1740,7 +1740,7 @@ export class JobsService {
                 projects: [
                   (organization)-[:HAS_PROJECT]->(project) | project {
                     .*,
-                    orgId: organization.orgId,
+                    orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                     discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                     website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
                     docs: [(project)-[:HAS_DOCSITE]->(docsite) | docsite.url][0],
@@ -1904,7 +1904,7 @@ export class JobsService {
                 projects: [
                   (organization)-[:HAS_PROJECT]->(project) | project {
                     .*,
-                    orgId: organization.orgId,
+                    orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                     discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                     website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
                     docs: [(project)-[:HAS_DOCSITE]->(docsite) | docsite.url][0],
@@ -2067,7 +2067,7 @@ export class JobsService {
                 projects: [
                   (organization)-[:HAS_PROJECT]->(project) | project {
                     .*,
-                    orgId: organization.orgId,
+                    orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                     discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                     website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
                     docs: [(project)-[:HAS_DOCSITE]->(docsite) | docsite.url][0],

--- a/src/organizations/organizations.service.ts
+++ b/src/organizations/organizations.service.ts
@@ -113,7 +113,7 @@ export class OrganizationsService {
           projects: [
             (organization)-[:HAS_PROJECT]->(project) | project {
               .*,
-              orgId: organization.orgId,
+              orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
               discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
               website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
               docs: [(project)-[:HAS_DOCSITE]->(docsite) | docsite.url][0],
@@ -506,7 +506,7 @@ export class OrganizationsService {
             projects: [
               (organization)-[:HAS_PROJECT]->(project) | project {
                 .*,
-                orgId: organization.orgId,
+                orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                 discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                 website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
                 docs: [(project)-[:HAS_DOCSITE]->(docsite) | docsite.url][0],
@@ -635,7 +635,7 @@ export class OrganizationsService {
             projects: [
               (organization)-[:HAS_PROJECT]->(project) | project {
                 .*,
-                orgId: organization.orgId,
+                orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                 discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                 website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
                 docs: [(project)-[:HAS_DOCSITE]->(docsite) | docsite.url][0],
@@ -750,7 +750,7 @@ export class OrganizationsService {
           projects: [
             (organization)-[:HAS_PROJECT]->(project) | project {
               .*,
-              orgId: organization.orgId,
+              orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
               discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
               website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
               docs: [(project)-[:HAS_DOCSITE]->(docsite) | docsite.url][0],
@@ -868,7 +868,7 @@ export class OrganizationsService {
           projects: [
             (organization)-[:HAS_PROJECT]->(project) | project {
               .*,
-              orgId: organization.orgId,
+              orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
               discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
               website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
               docs: [(project)-[:HAS_DOCSITE]->(docsite) | docsite.url][0],
@@ -1224,6 +1224,8 @@ export class OrganizationsService {
 
             WITH organization
             OPTIONAL MATCH (organization)-[:HAS_PROJECT]->(project)
+            WITH COUNT((org)-[:HAS_PROJECT]->(project) | org.orgId) === 1 AS shouldDelete, organization, project
+            WHERE shouldDelete
             OPTIONAL MATCH (project)-[:HAS_AUDIT]->(audit)
             OPTIONAL MATCH (project)-[:HAS_HACK]->(hack)
             OPTIONAL MATCH (project)-[:HAS_DISCORD]->(discord2)

--- a/src/projects/dto/update-project.input.ts
+++ b/src/projects/dto/update-project.input.ts
@@ -9,10 +9,5 @@ export class UpdateProjectInput extends OmitType(CreateProjectInput, [
   @ApiPropertyOptional()
   @IsOptional()
   @IsString()
-  orgId: string | null;
-
-  @ApiPropertyOptional()
-  @IsOptional()
-  @IsString()
   description: string | null;
 }

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -625,7 +625,7 @@ export class ProjectsController {
             data: {
               ...new ProjectMoreInfoEntity({
                 id: randomUUID(),
-                orgId: "-1",
+                orgIds: [],
                 name: project.name,
                 logo: project.logo,
                 tokenSymbol: project.symbol,

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -341,7 +341,9 @@ export class ProjectsService {
         ? new ProjectDetailsEntity(details).getProperties()
         : undefined;
       if (community) {
-        return result?.organization.community.includes(community)
+        return result?.organizations
+          .flatMap(x => x.community)
+          .includes(community)
           ? result
           : undefined;
       } else {
@@ -373,7 +375,9 @@ export class ProjectsService {
         ? new ProjectDetailsEntity(details).getProperties()
         : undefined;
       if (community) {
-        return result?.organization.community.includes(community)
+        return result?.organizations
+          .flatMap(x => x.community)
+          .includes(community)
           ? result
           : undefined;
       } else {
@@ -413,7 +417,6 @@ export class ProjectsService {
         projects.map(project => ({
           ...new ProjectWithRelationsEntity({
             ...project,
-            orgId: "-1",
           }).getProperties(),
           rawWebsite: project.rawWebsite
             ? {
@@ -489,11 +492,11 @@ export class ProjectsService {
     try {
       const projects = await this.models.Projects.getProjectsData();
       return projects
-        .filter(project => project.orgId === id)
+        .filter(project => project.orgIds.includes(id))
         .map(project => ({
           id: project.id,
           name: project.name,
-          orgId: project.orgId,
+          orgIds: project.orgIds,
           isMainnet: project.isMainnet,
           tvl: project.tvl,
           logo: project.logo,
@@ -629,7 +632,6 @@ export class ProjectsService {
         `
           CREATE (project:Project {
             id: randomUUID(),
-            orgId: $orgId,
             name: $name,
             normalizedName: $normalizedName,
             tvl: $tvl,
@@ -706,7 +708,7 @@ export class ProjectsService {
         const response2 = await axios.get(
           `${url}/project-importer/import-project-by-url?url=${dto.url}&name=${
             dto.name
-          }&orgId=${dto.orgId ?? ""}&defiLlamaSlug=${dto.defiLlamaSlug ?? ""}`,
+          }&defiLlamaSlug=${dto.defiLlamaSlug ?? ""}`,
           {
             headers: {
               Authorization: `Bearer ${authToken}`,
@@ -822,7 +824,6 @@ export class ProjectsService {
           OPTIONAL MATCH (project)-[:HAS_TWITTER]->(twitter: Twitter) 
           OPTIONAL MATCH (project)-[:HAS_GITHUB]->(github: Github)
           
-          SET project.orgId = $orgId
           SET project.name = $name
           SET project.normalizedName = $normalizedName
           SET project.tvl = $tvl
@@ -858,7 +859,6 @@ export class ProjectsService {
           ...project,
           id,
           normalizedName: normalizeString(project.name),
-          orgId: project.orgId ?? null,
           description: project.description ?? null,
         },
       );

--- a/src/shared/entities/project-details.entity.ts
+++ b/src/shared/entities/project-details.entity.ts
@@ -25,7 +25,7 @@ export class ProjectDetailsEntity {
 
     return new ProjectDetailsResult({
       ...project,
-      orgId: notStringOrNull(project?.orgId),
+      orgIds: project?.orgIds ?? [],
       defiLlamaId: notStringOrNull(project?.defiLlamaId),
       defiLlamaSlug: notStringOrNull(project?.defiLlamaSlug),
       defiLlamaParent: notStringOrNull(project?.defiLlamaParent),
@@ -69,56 +69,54 @@ export class ProjectDetailsEntity {
           logo: notStringOrNull(chain?.logo),
         })) ?? [],
       ecosystems: project.ecosystems ?? [],
-      organization: organization
-        ? {
-            ...organization,
-            aggregateRating:
-              reviews.length > 0
-                ? reviews.reduce((a, b) => a + b) / reviews.length
-                : 0,
-            aggregateRatings: generateOrgAggregateRatings(
-              organization?.reviews?.map(x => x.rating) ?? [],
-            ),
-            reviewCount: reviews.length,
-            docs: notStringOrNull(organization?.docs),
-            logoUrl: notStringOrNull(organization?.logoUrl),
-            headcountEstimate: nonZeroOrNull(organization?.headcountEstimate),
-            github: notStringOrNull(organization?.github),
-            twitter: notStringOrNull(organization?.twitter),
-            discord: notStringOrNull(organization?.discord),
-            telegram: notStringOrNull(organization?.telegram),
-            createdTimestamp: nonZeroOrNull(organization?.createdTimestamp),
-            updatedTimestamp: nonZeroOrNull(organization?.updatedTimestamp),
-            fundingRounds:
-              organization?.fundingRounds.map(fr => ({
-                ...fr,
-                raisedAmount: nonZeroOrNull(fr?.raisedAmount),
-                roundName: notStringOrNull(fr?.roundName),
-                sourceLink: notStringOrNull(fr?.sourceLink),
-                createdTimestamp: nonZeroOrNull(fr?.createdTimestamp),
-                updatedTimestamp: nonZeroOrNull(fr?.updatedTimestamp),
-              })) ?? [],
-            community: organization?.community ?? [],
-            grants: organization?.grants ?? [],
-            ecosystems: organization?.ecosystems ?? [],
-            investors: Array.from(
-              uniqBy(
-                organization?.investors?.map(investor => ({
-                  id: investor.id,
-                  name: investor.name,
-                  normalizedName: investor.normalizedName,
-                })) ?? [],
-                "id",
-              ),
-            ),
-            tags: organization?.tags ?? [],
-            projects: [],
-            reviews:
-              organization?.reviews.map(review =>
-                new OrgReviewEntity(review).getProperties(),
-              ) ?? [],
-          }
-        : null,
+      organizations: project?.organizations?.map(organization => ({
+        ...organization,
+        aggregateRating:
+          reviews.length > 0
+            ? reviews.reduce((a, b) => a + b) / reviews.length
+            : 0,
+        aggregateRatings: generateOrgAggregateRatings(
+          organization?.reviews?.map(x => x.rating) ?? [],
+        ),
+        reviewCount: reviews.length,
+        docs: notStringOrNull(organization?.docs),
+        logoUrl: notStringOrNull(organization?.logoUrl),
+        headcountEstimate: nonZeroOrNull(organization?.headcountEstimate),
+        github: notStringOrNull(organization?.github),
+        twitter: notStringOrNull(organization?.twitter),
+        discord: notStringOrNull(organization?.discord),
+        telegram: notStringOrNull(organization?.telegram),
+        createdTimestamp: nonZeroOrNull(organization?.createdTimestamp),
+        updatedTimestamp: nonZeroOrNull(organization?.updatedTimestamp),
+        fundingRounds:
+          organization?.fundingRounds.map(fr => ({
+            ...fr,
+            raisedAmount: nonZeroOrNull(fr?.raisedAmount),
+            roundName: notStringOrNull(fr?.roundName),
+            sourceLink: notStringOrNull(fr?.sourceLink),
+            createdTimestamp: nonZeroOrNull(fr?.createdTimestamp),
+            updatedTimestamp: nonZeroOrNull(fr?.updatedTimestamp),
+          })) ?? [],
+        community: organization?.community ?? [],
+        grants: organization?.grants ?? [],
+        ecosystems: organization?.ecosystems ?? [],
+        investors: Array.from(
+          uniqBy(
+            organization?.investors?.map(investor => ({
+              id: investor.id,
+              name: investor.name,
+              normalizedName: investor.normalizedName,
+            })) ?? [],
+            "id",
+          ),
+        ),
+        tags: organization?.tags ?? [],
+        projects: [],
+        reviews:
+          organization?.reviews.map(review =>
+            new OrgReviewEntity(review).getProperties(),
+          ) ?? [],
+      })),
       repos:
         project?.repos?.map(repo => ({
           ...repo,

--- a/src/shared/entities/project-list-result.entity.ts
+++ b/src/shared/entities/project-list-result.entity.ts
@@ -10,7 +10,7 @@ export class ProjectListResultEntity {
 
     return new ProjectListResult({
       ...project,
-      orgId: notStringOrNull(project?.orgId),
+      orgIds: project?.orgIds ?? [],
       tokenSymbol: notStringOrNull(project?.tokenSymbol, ["-"]),
       tvl: nonZeroOrNull(project?.tvl),
       monthlyVolume: nonZeroOrNull(project?.monthlyVolume),

--- a/src/shared/entities/project-more-info.entity.ts
+++ b/src/shared/entities/project-more-info.entity.ts
@@ -8,7 +8,7 @@ export class ProjectMoreInfoEntity {
     const project = this.raw;
     return new ProjectMoreInfo({
       ...project,
-      orgId: notStringOrNull(project?.orgId),
+      orgIds: project?.orgIds ?? [],
       description: notStringOrNull(project?.description),
       tokenSymbol: notStringOrNull(project?.tokenSymbol, ["-"]),
       tokenAddress: notStringOrNull(project?.tokenAddress, ["-"]),

--- a/src/shared/entities/project.entity.ts
+++ b/src/shared/entities/project.entity.ts
@@ -10,7 +10,7 @@ export class ProjectWithRelationsEntity {
     const project = this.raw;
     return new ProjectWithRelations({
       ...project,
-      orgId: notStringOrNull(project?.orgId),
+      orgIds: project?.orgIds ?? [],
       tokenSymbol: notStringOrNull(project?.tokenSymbol, ["-"]),
       tokenAddress: notStringOrNull(project?.tokenAddress, ["-"]),
       defiLlamaId: notStringOrNull(project?.defiLlamaId, ["-"]),

--- a/src/shared/interfaces/project-details-result.interface.ts
+++ b/src/shared/interfaces/project-details-result.interface.ts
@@ -11,27 +11,29 @@ export class ProjectDetailsResult extends ProjectWithRelations {
   public static readonly ProjectDetailsType = t.intersection([
     ProjectWithRelations.ProjectWithRelationsType,
     t.strict({
-      organization: t.union([
-        t.intersection([
-          OrganizationWithRelations.OrganizationWithRelationsType,
-          t.strict({ tags: t.array(Tag.TagType) }),
+      organizations: t.array(
+        t.union([
+          t.intersection([
+            OrganizationWithRelations.OrganizationWithRelationsType,
+            t.strict({ tags: t.array(Tag.TagType) }),
+          ]),
+          t.null,
         ]),
-        t.null,
-      ]),
+      ),
     }),
   ]);
 
   @ApiPropertyOptional()
-  organization: (OrganizationWithRelations & { tags: Tag[] }) | null;
+  organizations: (OrganizationWithRelations & { tags: Tag[] })[];
 
   constructor(raw: ProjectDetailsResult) {
-    const { organization, ...projectProps } = raw;
+    const { organizations, ...projectProps } = raw;
 
     super(projectProps);
 
     const result = ProjectDetailsResult.ProjectDetailsType.decode(raw);
 
-    this.organization = organization;
+    this.organizations = organizations;
 
     if (isLeft(result)) {
       report(result).forEach(x => {

--- a/src/shared/interfaces/project-list-result.interface.ts
+++ b/src/shared/interfaces/project-list-result.interface.ts
@@ -16,7 +16,7 @@ export class ProjectListResult {
   public static readonly ProjectListResultType = t.strict({
     id: t.string,
     name: t.string,
-    orgId: t.union([t.string, t.null]),
+    orgIds: t.array(t.string),
     normalizedName: t.string,
     website: t.union([t.string, t.null]),
     logo: t.union([t.string, t.null]),
@@ -45,7 +45,7 @@ export class ProjectListResult {
   name: string;
 
   @ApiProperty()
-  orgId: string | null;
+  orgIds: string[];
 
   @ApiProperty()
   normalizedName: string;
@@ -117,7 +117,7 @@ export class ProjectListResult {
     const {
       id,
       name,
-      orgId,
+      orgIds,
       website,
       logo,
       category,
@@ -142,7 +142,7 @@ export class ProjectListResult {
     this.id = id;
     this.tvl = tvl;
     this.name = name;
-    this.orgId = orgId;
+    this.orgIds = orgIds;
     this.logo = logo;
     this.hacks = hacks;
     this.audits = audits;

--- a/src/shared/interfaces/project.interface.ts
+++ b/src/shared/interfaces/project.interface.ts
@@ -19,7 +19,7 @@ export class Project {
     normalizedName: t.string,
     tvl: t.union([t.number, t.null]),
     logo: t.union([t.string, t.null]),
-    orgId: t.union([t.string, t.null]),
+    orgIds: t.array(t.string),
     isMainnet: t.union([t.boolean, t.null]),
     tokenSymbol: t.union([t.string, t.null]),
     monthlyFees: t.union([t.number, t.null]),
@@ -51,7 +51,7 @@ export class Project {
   @ApiPropertyOptional()
   isMainnet?: boolean | null;
   @ApiPropertyOptional()
-  orgId: string | null;
+  orgIds: string[];
 
   constructor(raw: Project) {
     const {
@@ -59,7 +59,7 @@ export class Project {
       tvl,
       name,
       logo,
-      orgId,
+      orgIds,
       isMainnet,
       tokenSymbol,
       monthlyFees,
@@ -75,7 +75,7 @@ export class Project {
     this.tvl = tvl;
     this.name = name;
     this.logo = logo;
-    this.orgId = orgId;
+    this.orgIds = orgIds;
     this.isMainnet = isMainnet;
     this.tokenSymbol = tokenSymbol;
     this.monthlyFees = monthlyFees;

--- a/src/shared/models/project.model.ts
+++ b/src/shared/models/project.model.ts
@@ -146,7 +146,7 @@ export const Projects = (
           allowEmpty: false,
           required: true,
         },
-        orgId: {
+        orgIds: {
           type: "string",
           allowEmpty: false,
           required: true,
@@ -290,7 +290,7 @@ export const Projects = (
           return {
             id: this.id,
             name: this.name,
-            orgId: this.orgId,
+            orgIds: this.orgIds,
             isMainnet: this.isMainnet,
             tvl: this.tvl,
             logo: this.logo,
@@ -374,6 +374,7 @@ export const Projects = (
               `
               project {
                   .*,
+                  orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                   discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                   website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
                   docs: [(project)-[:HAS_DOCSITE]->(docsite) | docsite.url][0],
@@ -499,7 +500,7 @@ export const Projects = (
               `
               project {
                   .*,
-                  orgId: [(org)-[:HAS_PROJECT]->(project) | org.orgId][0],
+                  orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                   orgName: [(org)-[:HAS_PROJECT]->(project) | org.name][0],
                   discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                   website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
@@ -602,7 +603,7 @@ export const Projects = (
               `
               project {
                   .*,
-                  orgId: [(org)-[:HAS_PROJECT]->(project) | org.orgId][0],
+                  orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                   orgName: [(org)-[:HAS_PROJECT]->(project) | org.name][0],
                   discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                   website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
@@ -695,7 +696,7 @@ export const Projects = (
               `
               project {
                   .*,
-                  orgId: [(org)-[:HAS_PROJECT]->(project) | org.orgId][0],
+                  orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                   orgName: [(org)-[:HAS_PROJECT]->(project) | org.name][0],
                   discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                   website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
@@ -704,7 +705,7 @@ export const Projects = (
                   github: [(project)-[:HAS_GITHUB]->(github:GithubOrganization) | github.login][0],
                   category: [(project)-[:HAS_CATEGORY]->(category) | category.name][0],
                   twitter: [(project)-[:HAS_TWITTER]->(twitter) | twitter.username][0],
-                  organization: [(organization)-[:HAS_PROJECT]->(project) | organization {
+                  organizations: [(organization)-[:HAS_PROJECT]->(project) | organization {
                     .*,
                     discord: [(organization)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                     website: [(organization)-[:HAS_WEBSITE]->(website) | website.url][0],
@@ -756,7 +757,7 @@ export const Projects = (
                         reviewedTimestamp: review.reviewedTimestamp
                       }
                     ]
-                  }][0],
+                  }],
                   hacks: [
                     (project)-[:HAS_HACK]->(hack) | hack { .* }
                   ],
@@ -845,7 +846,7 @@ export const Projects = (
               `
               project {
                   .*,
-                  orgId: [(org)-[:HAS_PROJECT]->(project) | org.orgId][0],
+                  orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                   orgName: [(org)-[:HAS_PROJECT]->(project) | org.name][0],
                   discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                   website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
@@ -854,7 +855,7 @@ export const Projects = (
                   github: [(project)-[:HAS_GITHUB]->(github:GithubOrganization) | github.login][0],
                   category: [(project)-[:HAS_CATEGORY]->(category) | category.name][0],
                   twitter: [(project)-[:HAS_TWITTER]->(twitter) | twitter.username][0],
-                  organization: [(organization)-[:HAS_PROJECT]->(project) | organization {
+                  organizations: [(organization)-[:HAS_PROJECT]->(project) | organization {
                     .*,
                     discord: [(organization)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                     website: [(organization)-[:HAS_WEBSITE]->(website) | website.url][0],
@@ -906,7 +907,7 @@ export const Projects = (
                         reviewedTimestamp: review.reviewedTimestamp
                       }
                     ]
-                  }][0],
+                  }],
                   hacks: [
                     (project)-[:HAS_HACK]->(hack) | hack { .* }
                   ],
@@ -955,7 +956,7 @@ export const Projects = (
           }).return(`
             project {
                 .*,
-                orgId: [(org)-[:HAS_PROJECT]->(project) | org.orgId][0]
+                orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId]
             }
           `);
           const result = await query.run(neogma.queryRunner);
@@ -1045,7 +1046,7 @@ export const Projects = (
               `
               project {
                   .*,
-                  orgId: [(org)-[:HAS_PROJECT]->(project) | org.orgId][0],
+                  orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId],
                   orgName: [(org)-[:HAS_PROJECT]->(project) | org.name][0],
                   discord: [(project)-[:HAS_DISCORD]->(discord) | discord.invite][0],
                   website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
@@ -1092,7 +1093,7 @@ export const Projects = (
           }).return(`
               project {
                   .*,
-                  orgId: [(org)-[:HAS_PROJECT]->(project) | org.orgId][0]
+                  orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId]
               }
             `);
           const result = await query.run(neogma.queryRunner);
@@ -1116,7 +1117,7 @@ export const Projects = (
             .raw("WHERE project.name =~ $query").return(`
               project {
                   .*,
-                  orgId: [(org)-[:HAS_PROJECT]->(project) | org.orgId][0]
+                  orgIds: [(org: Organization)-[:HAS_PROJECT]->(project) | org.orgId]
               }
             `);
           const result = await searchQuery.run(neogma.queryRunner);

--- a/yarn.lock
+++ b/yarn.lock
@@ -747,6 +747,18 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@faker-js/faker@^9.0.3":
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-9.0.3.tgz#be817db896b07d1716bc65d9aad1ba587b499826"
+  integrity sha512-lWrrK4QNlFSU+13PL9jMbMKLJYXDFu3tQfayBsMXX7KL/GiQeqfB1CzHkqD5UHBUtPAuPo6XwGbMFNdVMZObRA==
+
+"@fast-check/jest@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@fast-check/jest/-/jest-2.0.2.tgz#f8bcea58ce02fe38924e55cf11d9f25c7d14edae"
+  integrity sha512-MDBM3c18rvUo3r2VnUKG3eqWFnucuDC2kTuna3lQpn5nNwnsEtF//ewxUjmJEhSqN3crFDukrBK15rWLFoRYHw==
+  dependencies:
+    fast-check "^3.0.0"
+
 "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
@@ -5036,6 +5048,13 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
+fast-check@^3.0.0, fast-check@^3.22.0:
+  version "3.22.0"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-3.22.0.tgz#1a8153e9d6fbdcc60b818f447cbb9cac1fdd8fb6"
+  integrity sha512-8HKz3qXqnHYp/VCNn2qfjHdAdcI8zcSqOyX64GOMukp7SL2bfzfeDKjSd+UyECtejccaZv3LcvZTm9YDD22iCQ==
+  dependencies:
+    pure-rand "^6.1.0"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -9290,6 +9309,11 @@ pure-rand@^6.0.0:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.2.tgz#a9c2ddcae9b68d736a8163036f088a2781c8b306"
   integrity sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==
+
+pure-rand@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
+  integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
 
 pvtsutils@^1.3.2:
   version "1.3.2"


### PR DESCRIPTION
all major list endpoints with `organization` prop for projects now have it as organizations: `<RelevantOrganizationInterface>[]` and for all project interfaces with the `orgId` prop now have it as `orgIds: string[]`
i’ve also disabled the`orgId` prop on the update project endpoint cos its now irrelevant.

CLOSES: JOB-783