### PR TITLE
feat: org data on pillar pages, sitemap jobCount, verified timestamp on FE endpoints

### DIFF
--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -124,6 +124,7 @@ export class JobsService {
           featureStartDate: structured_jobpost.featureStartDate,
           featureEndDate: structured_jobpost.featureEndDate,
           timestamp: CASE WHEN structured_jobpost.publishedTimestamp IS NULL THEN structured_jobpost.firstSeenTimestamp ELSE structured_jobpost.publishedTimestamp END,
+          publishedTimestampIsVerified: structured_jobpost.publishedTimestampIsVerified,
           offersTokenAllocation: structured_jobpost.offersTokenAllocation,
           classification: [(structured_jobpost)-[:HAS_CLASSIFICATION]->(classification) | classification.name ][0],
           commitment: [(structured_jobpost)-[:HAS_COMMITMENT]->(commitment) | commitment.name ][0],
@@ -544,6 +545,7 @@ export class JobsService {
               isBlocked: CASE WHEN (structured_jobpost)-[:HAS_JOB_DESIGNATION]->(:BlockedDesignation) THEN true ELSE false END,
               isOnline: CASE WHEN (structured_jobpost)-[:HAS_STATUS]->(:JobpostOnlineStatus) THEN true ELSE false END,
               timestamp: CASE WHEN structured_jobpost.publishedTimestamp IS NULL THEN structured_jobpost.firstSeenTimestamp ELSE structured_jobpost.publishedTimestamp END,
+              publishedTimestampIsVerified: structured_jobpost.publishedTimestampIsVerified,
               classification: [(structured_jobpost)-[:HAS_CLASSIFICATION]->(classification) | classification.name ][0],
               commitment: [(structured_jobpost)-[:HAS_COMMITMENT]->(commitment) | commitment.name ][0],
               locationType: [(structured_jobpost)-[:HAS_LOCATION_TYPE]->(locationType) | locationType.name ][0],
@@ -1262,6 +1264,7 @@ export class JobsService {
           featureStartDate: structured_jobpost.featureStartDate,
           featureEndDate: structured_jobpost.featureEndDate,
           timestamp: CASE WHEN structured_jobpost.publishedTimestamp IS NULL THEN structured_jobpost.firstSeenTimestamp ELSE structured_jobpost.publishedTimestamp END,
+          publishedTimestampIsVerified: structured_jobpost.publishedTimestampIsVerified,
           offersTokenAllocation: structured_jobpost.offersTokenAllocation,
           classification: [(structured_jobpost)-[:HAS_CLASSIFICATION]->(classification) | classification.name ][0],
           commitment: [(structured_jobpost)-[:HAS_COMMITMENT]->(commitment) | commitment.name ][0],
@@ -4922,7 +4925,10 @@ export class JobsService {
     }
 
     const minOverlapRatio = isExpert ? 0.15 : 0.25;
-    const minMatchCount = Math.min(5, Math.max(1, Math.ceil(skills.length / 3)));
+    const minMatchCount = Math.min(
+      5,
+      Math.max(1, Math.ceil(skills.length / 3)),
+    );
     const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
     const skip = (page - 1) * limit;
 
@@ -5064,8 +5070,7 @@ export class JobsService {
           organization: org
             ? {
                 ...org,
-                headcountEstimate:
-                  intConverter(org.headcountEstimate) || null,
+                headcountEstimate: intConverter(org.headcountEstimate) || null,
                 fundingRounds: (org.fundingRounds ?? []).map(
                   (fr: Record<string, unknown>) => ({
                     ...fr,

--- a/src/search/dto/pillar-page.output.ts
+++ b/src/search/dto/pillar-page.output.ts
@@ -85,10 +85,25 @@ export interface SuggestedPillar {
 /**
  * Response data for a pillar page
  */
+/**
+ * Slim organization payload for o-* pillar pages: the real org copy shown
+ * instead of the templated pillar descriptor.
+ */
+export interface PillarPageOrg {
+  name: string;
+  normalizedName: string;
+  summary: string | null;
+  description: string | null;
+  logoUrl: string | null;
+  location: string | null;
+  website: string | null;
+}
+
 export interface PillarPageData {
   title: string;
   description: string;
   jobs: PillarJob[];
+  organization?: PillarPageOrg | null;
   suggestedPillars: SuggestedPillar[];
 }
 

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -14,6 +14,7 @@ import {
 import { subDays, startOfDay, endOfDay } from "date-fns";
 import {
   PillarPageData,
+  PillarPageOrg,
   PillarJob,
   ParsedPillarSlug,
   SuggestedPillar,
@@ -1444,10 +1445,16 @@ export class SearchService {
     // 1. Properties: locations + seniority (no relationship hops from sj)
     // 2-5. One-hop relationships: tags, commitments, locationTypes, classifications
     // 6. Org-dependent: organizations + investors + fundingRounds (share 3-hop traversal)
-    const [propsResult, tagsResult, commitmentsResult, locationTypesResult, classificationsResult, orgResult] =
-      await Promise.all([
-        this.neogma.queryRunner.run(
-          `${baseMatch}
+    const [
+      propsResult,
+      tagsResult,
+      commitmentsResult,
+      locationTypesResult,
+      classificationsResult,
+      orgResult,
+    ] = await Promise.all([
+      this.neogma.queryRunner.run(
+        `${baseMatch}
           RETURN
             [x IN collect(DISTINCT sj.location) WHERE x IS NOT NULL] AS locations,
             [x IN collect(DISTINCT CASE sj.seniority
@@ -1458,31 +1465,31 @@ export class SearchService {
               WHEN '5' THEN 'head'
               ELSE sj.seniority
             END) WHERE x IS NOT NULL] AS seniority`,
-        ),
-        this.neogma.queryRunner.run(
-          `${baseMatch}
+      ),
+      this.neogma.queryRunner.run(
+        `${baseMatch}
           MATCH (sj)-[:HAS_TAG]->(tag:Tag)
           WHERE NOT (tag)-[:HAS_TAG_DESIGNATION]-(:BlockedDesignation)
           AND NOT (tag)<-[:IS_PAIR_OF|IS_SYNONYM_OF]-(:Tag)--(:BlockedDesignation)
           RETURN DISTINCT tag.name as item`,
-        ),
-        this.neogma.queryRunner.run(
-          `${baseMatch}
+      ),
+      this.neogma.queryRunner.run(
+        `${baseMatch}
           MATCH (sj)-[:HAS_COMMITMENT]->(co:JobpostCommitment)
           RETURN DISTINCT co.name as item`,
-        ),
-        this.neogma.queryRunner.run(
-          `${baseMatch}
+      ),
+      this.neogma.queryRunner.run(
+        `${baseMatch}
           MATCH (sj)-[:HAS_LOCATION_TYPE]->(lt:JobpostLocationType)
           RETURN DISTINCT lt.name as item`,
-        ),
-        this.neogma.queryRunner.run(
-          `${baseMatch}
+      ),
+      this.neogma.queryRunner.run(
+        `${baseMatch}
           MATCH (sj)-[:HAS_CLASSIFICATION]->(cl:JobpostClassification)
           RETURN DISTINCT cl.name as item`,
-        ),
-        this.neogma.queryRunner.run(
-          `${baseMatch}
+      ),
+      this.neogma.queryRunner.run(
+        `${baseMatch}
           MATCH (sj)<-[:HAS_STRUCTURED_JOBPOST|HAS_JOBPOST|HAS_JOBSITE*3]-(org:Organization)
           WITH DISTINCT org
           OPTIONAL MATCH (org)-[:HAS_FUNDING_ROUND]->(fr:FundingRound)
@@ -1491,17 +1498,20 @@ export class SearchService {
             [x IN collect(DISTINCT org.name) WHERE x IS NOT NULL] AS organizations,
             [x IN collect(DISTINCT fr.roundName) WHERE x IS NOT NULL] AS fundingRounds,
             [x IN collect(DISTINCT investor.name) WHERE x IS NOT NULL] AS investors`,
-        ),
-      ]);
+      ),
+    ]);
 
     const toSlugs = (items: string[], prefix: string): string[] =>
       items.filter(Boolean).map(item => `${prefix}-${slugify(item)}`);
 
-    const extractItems = (result: { records: { get: (key: string) => unknown }[] }): string[] =>
-      result.records.map(r => r.get("item") as string);
+    const extractItems = (result: {
+      records: { get: (key: string) => unknown }[];
+    }): string[] => result.records.map(r => r.get("item") as string);
 
-    const extractList = (result: { records: { get: (key: string) => unknown }[] }, key: string): string[] =>
-      (result.records[0]?.get(key) as string[]) ?? [];
+    const extractList = (
+      result: { records: { get: (key: string) => unknown }[] },
+      key: string,
+    ): string[] => (result.records[0]?.get(key) as string[]) ?? [];
 
     return [
       ...toSlugs(extractItems(tagsResult), "t"),
@@ -1519,7 +1529,7 @@ export class SearchService {
   }
 
   async searchPillarSitemapSlugs(): Promise<
-    { slug: string; lastModified: string }[]
+    { slug: string; lastModified: string; jobCount: number }[]
   > {
     try {
       const jobLevelQuery = `
@@ -1544,8 +1554,8 @@ export class SearchService {
           CASE WHEN COALESCE(sj.onboardIntoWeb3, false) = true THEN [{type: 'booleans', item: 'onboardIntoWeb3'}] ELSE [] END AS boolEntries
 
         UNWIND (tagEntries + commitmentEntries + ltEntries + clEntries + locEntries + senEntries + boolEntries) AS entry
-        WITH entry.type AS type, entry.item AS item, MAX(ts) AS maxTs
-        RETURN type, item, maxTs
+        WITH entry.type AS type, entry.item AS item, MAX(ts) AS maxTs, COUNT(DISTINCT sj) AS jobCount
+        RETURN type, item, maxTs, jobCount
       `;
 
       const orgLevelQuery = `
@@ -1553,16 +1563,16 @@ export class SearchService {
         MATCH (sj:StructuredJobpost)-[:HAS_STATUS]->(:JobpostOnlineStatus)
         WHERE NOT (sj)-[:HAS_JOB_DESIGNATION]->(:BlockedDesignation)
         MATCH (sj)<-[:HAS_STRUCTURED_JOBPOST|HAS_JOBPOST|HAS_JOBSITE*3]-(org:Organization)
-        WITH org, MAX(COALESCE(sj.publishedTimestamp, sj.firstSeenTimestamp)) AS orgTs
+        WITH org, MAX(COALESCE(sj.publishedTimestamp, sj.firstSeenTimestamp)) AS orgTs, COUNT(DISTINCT sj) AS orgJobCount
 
-        WITH org, orgTs,
+        WITH org, orgTs, orgJobCount,
           [{type: 'organizations', item: org.name}] AS orgEntries,
           [x IN [(org)-[:HAS_FUNDING_ROUND]->(:FundingRound)-[:HAS_INVESTOR]->(inv:Investor) | {type: 'investors', item: inv.name}] WHERE x.item IS NOT NULL | x] AS invEntries,
           [x IN [(org)-[:HAS_FUNDING_ROUND]->(fr:FundingRound) | {type: 'fundingRounds', item: fr.roundName}] WHERE x.item IS NOT NULL | x] AS frEntries
 
         UNWIND (orgEntries + invEntries + frEntries) AS entry
-        WITH entry.type AS type, entry.item AS item, MAX(orgTs) AS maxTs
-        RETURN type, item, maxTs
+        WITH entry.type AS type, entry.item AS item, MAX(orgTs) AS maxTs, SUM(orgJobCount) AS jobCount
+        RETURN type, item, maxTs, jobCount
       `;
 
       const prefixMap = NAV_PILLAR_SLUG_PREFIX_MAPPINGS["jobs"];
@@ -1578,16 +1588,19 @@ export class SearchService {
           const type = record.get("type") as string;
           const item = record.get("item") as string;
           const maxTs = intConverter(record.get("maxTs"));
+          const jobCount = intConverter(record.get("jobCount")) ?? 0;
           if (!item || !type || !maxTs) return null;
           const prefix = prefixMap[type];
           if (!prefix) return null;
           return {
             slug: `${prefix}-${type === "booleans" ? item : slugify(item)}`,
             lastModified: new Date(maxTs).toISOString(),
+            jobCount,
           };
         })
         .filter(
-          (x): x is { slug: string; lastModified: string } => x !== null,
+          (x): x is { slug: string; lastModified: string; jobCount: number } =>
+            x !== null,
         );
     } catch (err) {
       Sentry.withScope(scope => {
@@ -2125,6 +2138,38 @@ export class SearchService {
    * @param ecosystem - Optional ecosystem filter
    * @returns ResponseWithOptionalData containing title, description, and filtered jobs
    */
+  private async getPillarPageOrganization(
+    normalizedName: string,
+  ): Promise<PillarPageOrg | null> {
+    const result = await this.neogma.queryRunner.run(
+      `
+        MATCH (org:Organization {normalizedName: $normalizedName})
+        RETURN {
+          name: org.name,
+          normalizedName: org.normalizedName,
+          summary: org.summary,
+          description: org.description,
+          logoUrl: org.logoUrl,
+          location: org.location,
+          website: [(org)-[:HAS_WEBSITE]->(website) | website.url][0]
+        } AS organization
+        LIMIT 1
+      `,
+      { normalizedName },
+    );
+    const org = result.records[0]?.get("organization");
+    if (!org) return null;
+    return {
+      name: org.name,
+      normalizedName: org.normalizedName,
+      summary: org.summary ?? null,
+      description: org.description ?? null,
+      logoUrl: org.logoUrl ?? null,
+      location: org.location ?? null,
+      website: org.website ?? null,
+    };
+  }
+
   async getPillarPageData(
     slug: string,
     ecosystem?: string,
@@ -2140,6 +2185,13 @@ export class SearchService {
       }
 
       const { pillarType, value } = parsed;
+
+      // Org pillars carry the real org copy so the frontend can render it
+      // instead of the templated descriptor (and still render at 0 jobs)
+      const organization =
+        pillarType === "organizations"
+          ? await this.getPillarPageOrganization(value)
+          : null;
 
       // Get title and description
       const headerText = await this.fetchHeaderText("jobs", pillarType, value);
@@ -2211,6 +2263,7 @@ export class SearchService {
             ELSE sj.seniority
           END,
           timestamp: COALESCE(sj.publishedTimestamp, sj.firstSeenTimestamp),
+          publishedTimestampIsVerified: sj.publishedTimestampIsVerified,
           commitment: [(sj)-[:HAS_COMMITMENT]->(c:JobpostCommitment) | c.name][0],
           locationType: [(sj)-[:HAS_LOCATION_TYPE]->(lt:JobpostLocationType) | lt.name][0],
           classification: [(sj)-[:HAS_CLASSIFICATION]->(cl:JobpostClassification) | cl.name][0],
@@ -2364,6 +2417,7 @@ export class SearchService {
                 title: headerText.title,
                 description: headerText.description,
                 jobs: fallbackJobs,
+                organization,
                 suggestedPillars: this.deriveSuggestedPillars(
                   fallbackJobs,
                   pillarType,
@@ -2375,8 +2429,22 @@ export class SearchService {
         }
       }
 
-      // No jobs found after all attempts
+      // No jobs found after all attempts. Org pillars still return the org
+      // data so their pages keep rendering real content instead of 404ing.
       if (jobs.length === 0) {
+        if (organization) {
+          return {
+            success: true,
+            message: "Retrieved pillar page data",
+            data: {
+              title: headerText.title,
+              description: headerText.description,
+              jobs: [],
+              organization,
+              suggestedPillars: [],
+            },
+          };
+        }
         return {
           success: true,
           message: "No jobs found for this pillar",
@@ -2391,6 +2459,7 @@ export class SearchService {
           title: headerText.title,
           description: headerText.description,
           jobs,
+          organization,
           suggestedPillars: this.deriveSuggestedPillars(
             jobs,
             pillarType,

--- a/src/search/v2/search-v2.controller.ts
+++ b/src/search/v2/search-v2.controller.ts
@@ -1,9 +1,4 @@
-import {
-  Controller,
-  Get,
-  UseGuards,
-  UseInterceptors,
-} from "@nestjs/common";
+import { Controller, Get, UseGuards, UseInterceptors } from "@nestjs/common";
 import { ApiOperation } from "@nestjs/swagger";
 import { SearchService } from "../search.service";
 import { PBACGuard } from "src/auth/pbac.guard";
@@ -33,7 +28,7 @@ export class SearchV2Controller {
   @UseGuards(PBACGuard)
   @UseInterceptors(new CacheHeaderInterceptor(CACHE_DURATION_1_HOUR))
   async searchSitemapPillars(): Promise<{
-    data: { slug: string; lastModified: string }[];
+    data: { slug: string; lastModified: string; jobCount: number }[];
   }> {
     this.logger.log("/v2/search/sitemap/pillars");
     const data = await this.searchService.searchPillarSitemapSlugs();

--- a/src/shared/interfaces/structured-jobpost.interface.ts
+++ b/src/shared/interfaces/structured-jobpost.interface.ts
@@ -30,6 +30,9 @@ export class StructuredJobpost {
     salaryCurrency: t.union([t.string, t.null]),
     timestamp: t.union([t.number, t.null]),
     offersTokenAllocation: t.union([t.boolean, t.null]),
+    // optional: not every projection returns it; true = publish date is
+    // verified (ATS/explicit), not inferred from first crawl
+    publishedTimestampIsVerified: t.union([t.boolean, t.null, t.undefined]),
   });
 
   @ApiProperty()
@@ -107,6 +110,9 @@ export class StructuredJobpost {
   @ApiProperty()
   timestamp: number | null;
 
+  @ApiPropertyOptional()
+  publishedTimestampIsVerified?: boolean | null;
+
   constructor(raw: StructuredJobpost) {
     const {
       id,
@@ -134,6 +140,7 @@ export class StructuredJobpost {
       responsibilities,
       timestamp,
       offersTokenAllocation,
+      publishedTimestampIsVerified,
     } = raw;
 
     const result = StructuredJobpost.StructuredJobpostType.decode(raw);
@@ -163,6 +170,7 @@ export class StructuredJobpost {
     this.responsibilities = responsibilities;
     this.timestamp = timestamp;
     this.offersTokenAllocation = offersTokenAllocation;
+    this.publishedTimestampIsVerified = publishedTimestampIsVerified ?? null;
 
     if (isLeft(result)) {
       report(result).forEach(x => {


### PR DESCRIPTION
Middleware side of the SEO/feedback round (webapp counterpart: jobstash/webapp#129). The FE is fallback-safe both before and after this deploys.

## publishedTimestampIsVerified on FE-consumed endpoints
12a4e645 added the field to the public endpoints only. Now also emitted by `/jobs/list`, `/jobs/details/{id}`, `/jobs/all`, and pillar-static jobs — added to the shared `StructuredJobpost` interface (optional in the io-ts codec so untouched projections keep validating).

## Org data on `o-*` pillar pages
`/search/pillar/page/static/o-*` now returns a top-level `organization { name, normalizedName, summary, description, logoUrl, location, website }` so the FE renders real org copy instead of the templated descriptor. **Bug fix:** org pillars with zero live jobs previously returned `data: null` (FE 404'd the page, e.g. `/o-opensea`); they now return the org with an empty jobs list.

## jobCount in `/v2/search/sitemap/pillars`
Each entry carries `jobCount` (job-level grouping `COUNT(DISTINCT sj)`; org-level entries sum per-org counts). The FE uses it to drop thin pillars from sitemaps — currently **4,637 of 8,351 slugs (55%) have <3 jobs**, which is the junk-pillar crawl bloat from the SEO audit.

## Verification
- `nest build` clean; changed files add no new lint errors (repo has pre-existing ones)
- Controller specs fail identically on clean main in this env (Node 26 removed `SlowBuffer`, breaking `jsonwebtoken`) — verified live instead
- Booted against real Neo4j and curled: `/jobs/list` (ptiv true/false values), `/jobs/details/{id}`, `o-bitrefill` (org + 3 jobs), `o-opensea`/`o-dapper-labs` (0 jobs + org, no more data:null), `t-react` (org null, unaffected), sitemap pillars (8,351 entries all with jobCount)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2r9SoF8wmxr5FHzrmX1bi