### PR TITLE
feat: full org metadata on pillar organization payload

### DIFF
--- a/src/search/dto/pillar-page.output.ts
+++ b/src/search/dto/pillar-page.output.ts
@@ -85,18 +85,39 @@ export interface SuggestedPillar {
 /**
  * Response data for a pillar page
  */
+export interface PillarPageOrgProject {
+  id: string;
+  name: string | null;
+  logo: string | null;
+  logoUrl: string | null;
+  website: string | null;
+  category: string | null;
+}
+
 /**
- * Slim organization payload for o-* pillar pages: the real org copy shown
+ * Organization payload for o-* pillar pages: the real org metadata shown
  * instead of the templated pillar descriptor.
  */
 export interface PillarPageOrg {
+  id: string | null;
+  orgId: string | null;
   name: string;
   normalizedName: string;
   summary: string | null;
   description: string | null;
   logoUrl: string | null;
   location: string | null;
+  headcountEstimate: number | null;
   website: string | null;
+  discord: string | null;
+  telegram: string | null;
+  github: string | null;
+  twitter: string | null;
+  docs: string | null;
+  aliases: string[];
+  projects: PillarPageOrgProject[];
+  fundingRounds: PillarFundingRound[];
+  investors: PillarInvestor[];
 }
 
 export interface PillarPageData {

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -2145,13 +2145,41 @@ export class SearchService {
       `
         MATCH (org:Organization {normalizedName: $normalizedName})
         RETURN {
+          id: org.id,
+          orgId: org.orgId,
           name: org.name,
           normalizedName: org.normalizedName,
           summary: org.summary,
           description: org.description,
           logoUrl: org.logoUrl,
           location: org.location,
-          website: [(org)-[:HAS_WEBSITE]->(website) | website.url][0]
+          headcountEstimate: org.headcountEstimate,
+          website: [(org)-[:HAS_WEBSITE]->(website) | website.url][0],
+          discord: [(org)-[:HAS_DISCORD]->(discord) | discord.invite][0],
+          telegram: [(org)-[:HAS_TELEGRAM]->(telegram) | telegram.username][0],
+          github: [(org)-[:HAS_GITHUB]->(github:GithubOrganization) | github.login][0],
+          twitter: [(org)-[:HAS_TWITTER]->(twitter) | twitter.username][0],
+          docs: [(org)-[:HAS_DOCSITE]->(docsite) | docsite.url][0],
+          aliases: [(org)-[:HAS_ORGANIZATION_ALIAS]->(alias) | alias.name],
+          projects: [(org)-[:HAS_PROJECT]->(project) | project {
+            id: project.id,
+            name: project.name,
+            logo: project.logo,
+            logoUrl: project.logoUrl,
+            website: [(project)-[:HAS_WEBSITE]->(website) | website.url][0],
+            category: [(project)-[:HAS_CATEGORY]->(category) | category.name][0]
+          }],
+          fundingRounds: [(org)-[:HAS_FUNDING_ROUND]->(fr:FundingRound) WHERE fr.id IS NOT NULL | {
+            id: fr.id,
+            date: fr.date,
+            roundName: fr.roundName,
+            raisedAmount: fr.raisedAmount
+          }],
+          investors: [(org)-[:HAS_FUNDING_ROUND]->(:FundingRound)-[:HAS_INVESTOR]->(inv:Investor) | {
+            id: inv.id,
+            name: inv.name,
+            normalizedName: inv.normalizedName
+          }]
         } AS organization
         LIMIT 1
       `,
@@ -2160,13 +2188,35 @@ export class SearchService {
     const org = result.records[0]?.get("organization");
     if (!org) return null;
     return {
+      id: org.id ?? null,
+      orgId: org.orgId ?? null,
       name: org.name,
       normalizedName: org.normalizedName,
       summary: org.summary ?? null,
       description: org.description ?? null,
       logoUrl: org.logoUrl ?? null,
       location: org.location ?? null,
+      headcountEstimate: intConverter(org.headcountEstimate) || null,
       website: org.website ?? null,
+      discord: org.discord ?? null,
+      telegram: org.telegram ?? null,
+      github: org.github ?? null,
+      twitter: org.twitter ?? null,
+      docs: org.docs ?? null,
+      aliases: org.aliases ?? [],
+      projects: (org.projects ?? []).map(
+        (project: Record<string, unknown>) => ({
+          ...project,
+        }),
+      ),
+      fundingRounds: (org.fundingRounds ?? []).map(
+        (fr: Record<string, unknown>) => ({
+          ...fr,
+          date: intConverter(fr.date as number),
+          raisedAmount: intConverter(fr.raisedAmount as number) || null,
+        }),
+      ),
+      investors: org.investors ?? [],
     };
   }
 


### PR DESCRIPTION
Companion to jobstash/webapp#130. The `o-*` pillar static `organization` object now carries the complete org metadata the frontend org card renders: orgId/headcount, socials (discord/telegram/twitter/github/docs), aliases, projects (name/logo/website/category), funding rounds, and investors — same depth as `/jobs/details`.

Verified live against Neo4j (`nest build` clean, node@20 boot + curl):
- `o-offchain-labs`: 4 socials, 5 Arbitrum projects with categories, Seed/$3.7M + Series A/$20M + Series B/$100M, investors
- `o-opensea` (0 live jobs): full org data still returned
- `t-react`: organization stays null, jobs unaffected

The FE is tolerant of both the old slim shape and this enriched one, so deploy order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2r9SoF8wmxr5FHzrmX1bi