### PR TITLE
Fix clean production Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN corepack enable && corepack prepare yarn@1.22.22 --activate
 
 # 1) Install (with dev) to build
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile --production=false
 
 # 2) Build
 COPY . .


### PR DESCRIPTION
## Summary
- force devDependencies to install in the Docker build stage even when Coolify injects `NODE_ENV=production`
- keep the runtime-stage production-only reinstall unchanged

## Verification
- `corepack yarn lint`
- `corepack yarn tsc --noEmit`
- `corepack yarn build`
- `corepack yarn test --runInBand` (253 enabled tests)
- clean Node 22 Alpine container build with `NODE_ENV=production`

This fixes the failed production build from deployment `p6fvfige8gxenww1sk8kdbjy`; the previous production container remained live.