### PR TITLE
fix(seo): align pillar sitemap eligibility

### DIFF
--- a/src/postgres/search.repository.integration.spec.ts
+++ b/src/postgres/search.repository.integration.spec.ts
@@ -157,7 +157,11 @@ describePostgres("SearchRepository PostgreSQL integration", () => {
   });
 
   it("aggregates job pillar sitemap entries with counts and timestamps", async () => {
-    const entries = await repository.getJobPillarSitemap();
+    const range = {
+      startDate: now - 86_400_000,
+      endDate: now + 86_400_000,
+    };
+    const entries = await repository.getJobPillarSitemap(range);
     expect(entries).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -176,6 +180,12 @@ describePostgres("SearchRepository PostgreSQL integration", () => {
         }),
       ]),
     );
+
+    await postgres.query(
+      "UPDATE job_search_documents SET published_timestamp = $1",
+      [range.startDate - 1],
+    );
+    await expect(repository.getJobPillarSitemap(range)).resolves.toEqual([]);
   });
 
   it("serves grouped and skill suggestions from recent job facets", async () => {

--- a/src/postgres/search.repository.ts
+++ b/src/postgres/search.repository.ts
@@ -442,7 +442,10 @@ export class SearchRepository {
     return rows.map(row => row.payload);
   }
 
-  async getJobPillarSitemap(): Promise<PillarSitemapEntry[]> {
+  async getJobPillarSitemap(options: {
+    startDate: number;
+    endDate: number;
+  }): Promise<PillarSitemapEntry[]> {
     const rows = await this.postgres.query<{
       type: string;
       key: string;
@@ -454,7 +457,10 @@ export class SearchRepository {
         WITH active AS MATERIALIZED (
           SELECT *
           FROM job_search_documents
-          WHERE online AND NOT blocked AND published_timestamp IS NOT NULL
+          WHERE online
+            AND NOT blocked
+            AND published_timestamp >= $1
+            AND published_timestamp <= $2
         ), facets AS (
           SELECT 'tags'::text AS type, entry.key, entry.value AS label,
             job_node_id, published_timestamp
@@ -534,6 +540,7 @@ export class SearchRepository {
         GROUP BY type, key
         ORDER BY type, key
       `,
+      [options.startDate, options.endDate],
     );
     return rows.map(row => ({
       type: row.type,

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -321,7 +321,9 @@ export class SearchService {
   }
 
   async searchJobPillarSlugs(): Promise<string[]> {
-    const entries = await this.searchRepository.getJobPillarSitemap();
+    const entries = await this.searchRepository.getJobPillarSitemap(
+      this.getPillarDateRange(),
+    );
     const slugs = entries.flatMap(entry => {
       const prefix = NAV_PILLAR_SLUG_PREFIX_MAPPINGS.jobs[entry.type];
       if (!prefix) return [];
@@ -336,7 +338,9 @@ export class SearchService {
     { slug: string; lastModified: string; jobCount: number }[]
   > {
     try {
-      const entries = await this.searchRepository.getJobPillarSitemap();
+      const entries = await this.searchRepository.getJobPillarSitemap(
+        this.getPillarDateRange(),
+      );
       return entries.flatMap(entry => {
         const prefix = NAV_PILLAR_SLUG_PREFIX_MAPPINGS.jobs[entry.type];
         if (!prefix || !entry.lastModified) return [];


### PR DESCRIPTION
## Summary
- apply the same 30-day publication window to pillar sitemap aggregation that pillar pages use
- exclude historical-only facets that render noindex or 404 pages
- keep sitemap counts and last-modified timestamps aligned with current public jobs

## Root cause
The sitemap repository counted all-time online jobs, while pillar pages only queried jobs from the last 30 days and become noindex below three results. Search Console therefore received many URLs the live page correctly marked noindex.

## Validation
- Nest build passes
- ESLint passes on changed files
- full unit suite: 255 passed
- PostgreSQL integration suite: 15 passed, including the new out-of-window exclusion assertion