### PR TITLE
fix(seo): resolve pillar pages by facet key

### DIFF
--- a/src/postgres/search.repository.integration.spec.ts
+++ b/src/postgres/search.repository.integration.spec.ts
@@ -154,6 +154,41 @@ describePostgres("SearchRepository PostgreSQL integration", () => {
         value: "rust",
       }),
     ).resolves.toEqual([]);
+
+    // Sitemap URLs are built from normalized filter-label keys. Legacy array
+    // values may still contain punctuation, so page lookup must use the same
+    // keys or valid sitemap URLs such as t-fp-a and i-11-11-media will 404.
+    await postgres.query(
+      `
+        UPDATE job_search_documents
+        SET tags = ARRAY['FP&A'],
+          investor_names = ARRAY['11/11 MEDIA (Eleven Eleven Media)'],
+          filter_labels = $1::jsonb
+      `,
+      [
+        JSON.stringify({
+          tags: { "fp-a": "FP&A" },
+          investors: {
+            "11-11-media-eleven-eleven-media":
+              "11/11 MEDIA (Eleven Eleven Media)",
+          },
+        }),
+      ],
+    );
+    await expect(
+      repository.getPillarJobs({
+        ...base,
+        pillarType: "tags",
+        value: "fp-a",
+      }),
+    ).resolves.toHaveLength(1);
+    await expect(
+      repository.getPillarJobs({
+        ...base,
+        pillarType: "investors",
+        value: "11-11-media-eleven-eleven-media",
+      }),
+    ).resolves.toHaveLength(1);
   });
 
   it("aggregates job pillar sitemap entries with counts and timestamps", async () => {

--- a/src/postgres/search.repository.ts
+++ b/src/postgres/search.repository.ts
@@ -372,25 +372,27 @@ export class SearchRepository {
         `${bind(slugify(options.ecosystem))} = ANY(job.managed_ecosystems)`,
       );
     }
+    const hasFacetKey = (facet: string, key: string): string =>
+      `COALESCE(job.filter_labels -> '${facet}', '{}'::jsonb) ? ${bind(key)}`;
     const value = options.value;
     switch (options.pillarType) {
       case "tags":
-        predicates.push(`${bind(value)} = ANY(job.tags)`);
+        predicates.push(hasFacetKey("tags", value));
         break;
       case "classifications":
-        predicates.push(`${bind(value)} = ANY(job.classifications)`);
+        predicates.push(hasFacetKey("classifications", value));
         break;
       case "locations":
         predicates.push(`slugify_text(job.location) = ${bind(value)}`);
         break;
       case "commitments":
-        predicates.push(`${bind(value)} = ANY(job.commitments)`);
+        predicates.push(hasFacetKey("commitments", value));
         break;
       case "locationTypes":
-        predicates.push(`${bind(value)} = ANY(job.location_types)`);
+        predicates.push(hasFacetKey("locationTypes", value));
         break;
       case "organizations":
-        predicates.push(`organization.normalized_name = ${bind(value)}`);
+        predicates.push(hasFacetKey("organizations", value));
         break;
       case "seniority": {
         const seniority =
@@ -401,10 +403,10 @@ export class SearchRepository {
         break;
       }
       case "investors":
-        predicates.push(`${bind(value)} = ANY(job.investor_names)`);
+        predicates.push(hasFacetKey("investors", value));
         break;
       case "fundingRounds":
-        predicates.push(`${bind(value)} = ANY(job.funding_round_names)`);
+        predicates.push(hasFacetKey("fundingRounds", value));
         break;
       case "booleans":
         if (value === "expertJobs") predicates.push("job.access = 'protected'");


### PR DESCRIPTION
## Summary
- resolve pillar-page jobs using normalized filter-label keys
- keep page lookup identical to the facet keys used to generate sitemap URLs
- cover punctuation-sensitive tags and investors with PostgreSQL integration assertions

## Production evidence
Post-deploy acceptance sampling found 404s for normalized URLs including t-fp-a, t-lloyd-s-market, i-11-11-media-eleven-eleven-media, and i-ant-capital-a-t-capital. Their sitemap counts were valid, but legacy job arrays retained punctuation while filter_labels held the URL-safe keys.

## Validation
- Nest build passes
- ESLint passes
- PostgreSQL integration suite: 15 passed