### PR TITLE
fix(seo): exclude unavailable jobs from sitemap

### DIFF
--- a/src/postgres/search.repository.integration.spec.ts
+++ b/src/postgres/search.repository.integration.spec.ts
@@ -287,6 +287,13 @@ describePostgres("SearchRepository PostgreSQL integration", () => {
         timestamp: now,
       },
     ]);
+
+    // The public detail lookup excludes jobs without tags. Keep the sitemap
+    // on the same eligibility contract so it never submits a known 404 URL.
+    await postgres.query(
+      "UPDATE job_search_documents SET tags = ARRAY[]::text[]",
+    );
+    await expect(repository.getSitemapJobs()).resolves.toEqual([]);
   });
 
   it("has the projection indexes used by search paths", async () => {

--- a/src/postgres/search.repository.ts
+++ b/src/postgres/search.repository.ts
@@ -749,7 +749,9 @@ export class SearchRepository {
           organization_name AS "organizationName",
           published_timestamp::text AS timestamp
         FROM job_search_documents
-        WHERE online AND NOT blocked
+        WHERE online
+          AND NOT blocked
+          AND cardinality(tags) > 0
         ORDER BY published_timestamp DESC NULLS LAST, job_node_id
       `,
     );


### PR DESCRIPTION
## Summary
- apply the public job-detail eligibility requirement to the sitemap query
- exclude online projection rows with no tags because /jobs/details/:uuid intentionally returns 404 for them
- cover the mismatch with a PostgreSQL integration assertion

## Production evidence
Acceptance sampling after the sitemap rollout found Px2OJe and 0SgEEO in the live sitemap while their detail endpoint returned 404. Both rows lack the tag eligibility required by getJobByShortUuid.

## Validation
- Nest build passes
- ESLint passes
- PostgreSQL integration suite: 15 passed